### PR TITLE
Generate a library with cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ list(SORT providers)
 set(GENERATED_CPP_FILE
     "#include <array>\n"
     "#include <string_view>\n"
+    "#include <algorithm>\n"
     "\n"
     "static std::array<std::string_view, ${providers_len}> const bad_providers {"
 )
@@ -41,6 +42,11 @@ set(GENERATED_CPP_FILE
     "\t\t*size = bad_providers.size()\;\n"
     "\t}\n"
     "\treturn bad_providers.data()\;\n"
+    "}\n"
+    "\n"
+    "bool is_bad_provider(std::string_view provider) noexcept\n"
+    "{\n"
+    "\treturn std::binary_search(bad_providers.begin(), bad_providers.end(), provider)\;\n"
     "}\n")
 
 set(GENERATED_HPP_FILE
@@ -49,6 +55,7 @@ set(GENERATED_HPP_FILE
     "#include <string_view>\n"
     "\n"
     "std::string_view const *get_bad_providers(std::size_t *size) noexcept\;\n"
+    "bool is_bad_provider(std::string_view provider) noexcept\;\n"
     "\n"
     "#endif\n")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,32 +1,68 @@
-cmake_minimum_required (VERSION 3.5)
+cmake_minimum_required(VERSION 3.5)
 
-set (project BadEmailsAutogen)
-project (
-        ${project}
-        DESCRIPTION "Generates C++ header file from the text file"
-        LANGUAGES CXX
-)
+project(BadEmailsAutogen DESCRIPTION "Generates C++ header file from the text file" LANGUAGES CXX C)
 
-message ("Configuring ${project}...")
+message(STATUS "Configuring ${CMAKE_PROJECT_NAME}...")
+
 
 # Read providers file as individual strings
-file (STRINGS "providers.txt" providers)
+file(STRINGS "providers.txt" providers)
+
+list(LENGTH providers providers_len)
+list(SORT providers)
 
 # Write the includes, and the set define
-set (GENERATED_CPP_FILE "#ifndef BAD_EMAIL_PROVIDERS_GENERATED_H\n#define BAD_EMAIL_PROVIDERS_GENERATED_H\n\n#include <string>\n#include <unordered_set>\n\nstd::unordered_set<std::string> bad_providers({")
+set(GENERATED_CPP_FILE
+    "#include <array>\n"
+    "#include <string_view>\n"
+    "\n"
+    "static std::array<std::string_view, ${providers_len}> const bad_providers {"
+)
+
 
 # Add all items from the list
-foreach (provider ${providers})
-    set (GENERATED_CPP_FILE "${GENERATED_CPP_FILE}\n\t\"${provider}\",")
-endforeach ()
+foreach(provider ${providers})
+    set(GENERATED_CPP_FILE "${GENERATED_CPP_FILE}\n\t\"${provider}\",")
+endforeach()
 
 # Remove last comma
-string (LENGTH ${GENERATED_CPP_FILE} generated_length)
-math (EXPR generated_length "${generated_length} - 1")
-string (SUBSTRING ${GENERATED_CPP_FILE} 0 ${generated_length} GENERATED_CPP_FILE)
+# string (LENGTH ${GENERATED_CPP_FILE} generated_length)
+# math (EXPR generated_length "${generated_length} - 1")
+# string (SUBSTRING ${GENERATED_CPP_FILE} 0 ${generated_length} GENERATED_CPP_FILE)
 
 # Add closing brcket and semicolon
-set (GENERATED_CPP_FILE "${GENERATED_CPP_FILE}\n})\;\n\n#endif")
+set(GENERATED_CPP_FILE
+    "${GENERATED_CPP_FILE}\n"
+    "}\;\n"
+    "\n"
+    "std::string_view const *get_bad_providers(std::size_t *size) noexcept\n"
+    "{\n"
+    "\tif (size) {\n"
+    "\t\t*size = bad_providers.size()\;\n"
+    "\t}\n"
+    "\treturn bad_providers.data()\;\n"
+    "}\n")
+
+set(GENERATED_HPP_FILE
+    "#ifndef BAD_EMAIL_PROVIDERS_GENERATED_HPP\n"
+    "#define BAD_EMAIL_PROVIDERS_GENERATED_H\n"
+    "#include <string_view>\n"
+    "\n"
+    "std::string_view const *get_bad_providers(std::size_t *size) noexcept\;\n"
+    "\n"
+    "#endif\n")
 
 # Write to output
-file (WRITE ${CMAKE_CURRENT_BINARY_DIR}/generated_providers.h ${GENERATED_CPP_FILE})
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/generated_providers.cpp ${GENERATED_CPP_FILE})
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/bad_emails/generated_providers.hpp ${GENERATED_HPP_FILE})
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_library(${CMAKE_PROJECT_NAME})
+target_sources(${CMAKE_PROJECT_NAME}
+    PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/generated_providers.cpp
+    PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/bad_emails/generated_providers.hpp)
+target_include_directories(${CMAKE_PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/bad_emails/)
+
+ 


### PR DESCRIPTION
Instead of just generating a single header file, this will generate a source file and a header file, which will be built to a library (static by default).
This add two public function:
- `std::string_view const *get_bad_providers(std::size_t *size) noexcept`
- `bool is_bad_provider(std::string_view provider) noexcept`
The first one returns a pointer to the first element in the static array of bad providers, and if `size` is not null, `*size` will contain the size of the array.
The second one simply checks if `provider` is in the array.

To use, simply link your target to `BadEmailsAutogen`